### PR TITLE
:bug: Packet Id can be modified during parallel operations

### DIFF
--- a/src/SocketIOClient/SocketIO.cs
+++ b/src/SocketIOClient/SocketIO.cs
@@ -705,8 +705,9 @@ namespace SocketIOClient
             Action<SocketIOResponse> ack,
             params object[] data)
         {
-            _ackActionHandlers.Add(++_packetId, ack);
-            await EmitForAck(eventName, _packetId, cancellationToken, data).ConfigureAwait(false);
+            var msgPacketId = ++_packetId;
+            _ackActionHandlers.Add(msgPacketId, ack);
+            await EmitForAck(eventName, msgPacketId, cancellationToken, data).ConfigureAwait(false);
         }
 
         private async Task EmitAsync(
@@ -715,8 +716,9 @@ namespace SocketIOClient
             Func<SocketIOResponse, Task> ack,
             params object[] data)
         {
-            _ackFuncHandlers.Add(++_packetId, ack);
-            await EmitForAck(eventName, _packetId, cancellationToken, data).ConfigureAwait(false);
+            var msgPacketId = ++_packetId;
+            _ackFuncHandlers.Add(msgPacketId, ack);
+            await EmitForAck(eventName, msgPacketId, cancellationToken, data).ConfigureAwait(false);
         }
 
 


### PR DESCRIPTION
When executing is performed in parallel the _packetId might get updated prior to being sent across the wire. This modification ensures that the same id is used to store response handles and the emitted event.

Sorry this was edited in the web UI.

I'm pretty sure I'm currently hitting this bug and would appreciate a release with a fix :D